### PR TITLE
Add support for metric prefix to signalfx library

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
   * Start feature "Add support for metric prefix to signalfx library"
   https://www.pivotaltracker.com/story/show/99153876
+  https://github.com/zvelo/go-signalfx/pull/5
 
 2015-07-29  Bob Uhl <buhl@zvelo.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-08-14  Bob Uhl <buhl@zvelo.com>
+
+  * Start feature "Add support for metric prefix to signalfx library"
+  https://www.pivotaltracker.com/story/show/99153876
+
 2015-07-29  Bob Uhl <buhl@zvelo.com>
 
   * Start feature "Example code for using signalfx"


### PR DESCRIPTION
In order to support ZVELO_ENV, it would be useful for the signalfx library to support a single prefix prepended to all metrics.

PIVOTAL_TRACKER_STORY_URL=https://www.pivotaltracker.com/story/show/99153876
PIVOTAL_TRACKER_STORY_TYPE=feature
PIVOTAL_TRACKER_STORY_ESTIMATE=1
PIVOTAL_TRACKER_STORY_OWNER=bobuhl
PIVOTAL_TRACKER_STORY_REQUESTER=bobuhl
PIVOTAL_TRACKER_STORY_LABELS=signalfx
