### PR TITLE
add stable gauge to signalfx library

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
   * Start feature "add stable gauge to signalfx library"
   https://www.pivotaltracker.com/story/show/117575937
+  https://github.com/zvelo/go-signalfx/pull/11
 
 2015-08-14  Bob Uhl <buhl@zvelo.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-04-13  Michael Robinson <mrobinson@zvelo.com>
+
+  * Start feature "add stable gauge to signalfx library"
+  https://www.pivotaltracker.com/story/show/117575937
+
 2015-08-14  Bob Uhl <buhl@zvelo.com>
 
   * Start feature "Add support for metric prefix to signalfx library"

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -36,6 +36,40 @@ func TestGauge(t *testing.T) {
 		So(gdp.Value, ShouldEqual, 12)
 		So(t.Before(gdp.Timestamp), ShouldBeTrue)
 	})
+	Convey("StableGauge works as specified", t, func() {
+		g := NewStableGauge("stable-gauge", nil, 0)
+		So(g, ShouldNotBeNil)
+		So(g.gauge.metric, ShouldEqual, "stable-gauge")
+		So(g.gauge.dimensions, ShouldBeNil)
+		So(g.gauge.value, ShouldEqual, 0)
+
+		g.Record(12)
+		So(g.gauge.value, ShouldEqual, 12)
+
+		gdp := g.DataPoint()
+		So(gdp, ShouldNotBeNil)
+		So(gdp.Metric, ShouldEqual, "stable-gauge")
+		So(gdp.Dimensions, ShouldBeNil)
+		So(gdp.Value, ShouldEqual, 12)
+		So(g.prevValue, ShouldEqual, 12)
+		t := gdp.Timestamp
+
+		// calling g.DataPoint repeatedly without changing the value should yield nil
+		time.Sleep(time.Millisecond)
+		gdp = g.DataPoint()
+		So(gdp, ShouldBeNil)
+		So(g.prevValue, ShouldEqual, 12)
+
+		g.Record(8)
+		// value has changed, so g.Datapoint should return a new DataPoint
+		gdp = g.DataPoint()
+		So(gdp, ShouldNotBeNil)
+		So(gdp.Metric, ShouldEqual, "stable-gauge")
+		So(gdp.Dimensions, ShouldBeNil)
+		So(gdp.Value, ShouldEqual, 8)
+		So(g.prevValue, ShouldEqual, 8)
+		So(t.Before(gdp.Timestamp), ShouldBeTrue)
+	})
 	Convey("Broken wrapped gauges break cleanly", t, func() {
 		g := WrapGauge("broken", nil, GetterFunc(func() (interface{}, error) {
 			return 0, fmt.Errorf("this is an error")


### PR DESCRIPTION
Add a &quot;stable gauge&quot; to &#x60;go-signalfx&#x60; that doesn&#x27;t report if the value hasn&#x27;t changed.

PIVOTAL_TRACKER_STORY_URL=https://www.pivotaltracker.com/story/show/117575937
PIVOTAL_TRACKER_STORY_TYPE=feature
PIVOTAL_TRACKER_STORY_ESTIMATE=2
PIVOTAL_TRACKER_STORY_OWNER=michaeltrobinson
PIVOTAL_TRACKER_STORY_REQUESTER=michaeltrobinson
PIVOTAL_TRACKER_STORY_LABELS=go-signalfx, signalfx
